### PR TITLE
sqlite: fix nil deref on missing response

### DIFF
--- a/pkg/db/sqlite/sqlite.go
+++ b/pkg/db/sqlite/sqlite.go
@@ -485,6 +485,9 @@ func (c *Client) queryHeaders(
 		}
 		defer resHeadersStmt.Close()
 		for i := range reqLogs {
+			if reqLogs[i].Response == nil {
+				continue
+			}
 			headers, err := findHeaders(ctx, resHeadersStmt, reqLogs[i].Response.ID)
 			if err != nil {
 				return fmt.Errorf("could not query response headers: %v", err)


### PR DESCRIPTION
I tested it out a bit, and immediately hit this error: 
```
020/10/07 13:52:26 [ERROR] Could not store request log: sqlite: could not prepare statement: context canceled
runtime error: invalid memory address or nil pointer dereference

goroutine 102 [running]:
runtime/debug.Stack(0x1, 0x0, 0x0)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
runtime/debug.PrintStack()
	/usr/local/go/src/runtime/debug/stack.go:16 +0x22
github.com/99designs/gqlgen/graphql.DefaultRecover(0x103cb20, 0xc000190360, 0xa327a0, 0x13bd090, 0xc0001a8410, 0x0)
	/home/user/go/pkg/mod/github.com/99designs/gqlgen@v0.11.3/graphql/recovery.go:16 +0xa7
github.com/dstotijn/hetty/pkg/api.(*executionContext)._Query_httpRequestLog.func1(0xc00017c3f0, 0xc00017c530, 0xc0001a9468)
	/home/user/go/src/github.com/dstotijn/hetty/pkg/api/generated.go:930 +0x78
panic(0xa327a0, 0x13bd090)
	/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/dstotijn/hetty/pkg/db/sqlite.(*Client).queryHeaders(0xc0000100e0, 0x103cb20, 0xc000190360, 0xc00054cd00, 0xb, 0x10, 0xc000130280, 0x2, 0x2, 0xc0001302c0, ...)
	/home/user/go/src/github.com/dstotijn/hetty/pkg/db/sqlite/sqlite.go:488 +0x4c6
github.com/dstotijn/hetty/pkg/db/sqlite.(*Client).FindRequestLogByID(0xc0000100e0, 0x103cb20, 0xc000190360, 0x6a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/user/go/src/github.com/dstotijn/hetty/pkg/db/sqlite/sqlite.go:208 +0x65c
github.com/dstotijn/hetty/pkg/reqlog.(*Service).FindRequestLogByID(...)
	/home/user/go/src/github.com/dstotijn/hetty/pkg/reqlog/reqlog.go:75
github.com/dstotijn/hetty/pkg/api.(*queryResolver).HTTPRequestLog(0xc0000be078, 0x103cb20, 0xc000190360, 0x6a, 0xc0002e4868, 0xc000600000, 0x7083534e1108)
	/home/user/go/src/github.com/dstotijn/hetty/pkg/api/resolvers.go:41 +0xa9
github.com/dstotijn/hetty/pkg/api.(*executionContext)._Query_httpRequestLog.func2(0x103cb20, 0xc000190360, 0x20, 0xa78e00, 0xc000190301, 0xc0001301e0)
	/home/user/go/src/github.com/dstotijn/hetty/pkg/api/generated.go:951 +0xf2
github.com/99designs/gqlgen/graphql/executor.processExtensions.func3(0x103cb20, 0xc000190360, 0xc0001301e0, 0xc000190390, 0xc0001903c0, 0x0, 0x0)
	/home/user/go/pkg/mod/github.com/99designs/gqlgen@v0.11.3/graphql/executor/extensions.go:62 +0x3a
github.com/dstotijn/hetty/pkg/api.(*executionContext)._Query_httpRequestLog(0xc00017c3f0, 0x103cb20, 0xc000190330, 0xc000165400, 0xc0005ca280, 0x8, 0x8, 0x0, 0x0)
	/home/user/go/src/github.com/dstotijn/hetty/pkg/api/generated.go:949 +0x2af
github.com/dstotijn/hetty/pkg/api.(*executionContext)._Query.func1(0x0, 0x0)
	/home/user/go/src/github.com/dstotijn/hetty/pkg/api/generated.go:2291 +0x9c
github.com/99designs/gqlgen/graphql.(*FieldSet).Dispatch(0xc00016c190)
	/home/user/go/pkg/mod/github.com/99designs/gqlgen@v0.11.3/graphql/fieldset.go:34 +0x1d4
github.com/dstotijn/hetty/pkg/api.(*executionContext)._Query(0xc00017c3f0, 0x103cb20, 0xc000190300, 0xc0001f4b80, 0x1, 0x1, 0x413b56, 0xc000190300)
	/home/user/go/src/github.com/dstotijn/hetty/pkg/api/generated.go:2316 +0x413
github.com/dstotijn/hetty/pkg/api.(*executableSchema).Exec.func1(0x103cb20, 0xc000190300, 0x10)
	/home/user/go/src/github.com/dstotijn/hetty/pkg/api/generated.go:243 +0x7b
github.com/99designs/gqlgen/graphql/executor.(*Executor).DispatchOperation.func1.1.1(0x103cb20, 0xc000190300, 0xc00017c430)
	/home/user/go/pkg/mod/github.com/99designs/gqlgen@v0.11.3/graphql/executor/executor.go:105 +0x43
github.com/99designs/gqlgen/graphql/executor.processExtensions.func2(0x103cb20, 0xc000190300, 0xc00017c430, 0x10241e0)
	/home/user/go/pkg/mod/github.com/99designs/gqlgen@v0.11.3/graphql/executor/extensions.go:59 +0x3a
github.com/99designs/gqlgen/graphql/executor.(*Executor).DispatchOperation.func1.1(0x103cb20, 0xc0001902a0, 0xc000190180)
	/home/user/go/pkg/mod/github.com/99designs/gqlgen@v0.11.3/graphql/executor/executor.go:104 +0x12a
github.com/99designs/gqlgen/graphql/handler/transport.POST.Do(0x103b720, 0xc0001e4e00, 0xc00054c500, 0x103b0a0, 0xc000516000)
	/home/user/go/pkg/mod/github.com/99designs/gqlgen@v0.11.3/graphql/handler/transport/http_post.go:52 +0x353
github.com/99designs/gqlgen/graphql/handler.(*Server).ServeHTTP(0xc00000f9a0, 0x103b720, 0xc0001e4e00, 0xc00054c500)
	/home/user/go/pkg/mod/github.com/99designs/gqlgen@v0.11.3/graphql/handler/server.go:115 +0x1fd
github.com/gorilla/mux.(*Router).ServeHTTP(0xc0003360c0, 0x103b720, 0xc0001e4e00, 0xc00054c200)
	/home/user/go/pkg/mod/github.com/gorilla/mux@v1.7.4/mux.go:210 +0xe2
net/http.serverHandler.ServeHTTP(0xc00032a1c0, 0x103b720, 0xc0001e4e00, 0xc00054c200)
	/usr/local/go/src/net/http/server.go:2807 +0xa3
net/http.(*conn).serve(0xc0000b2c80, 0x103ca60, 0xc000298e40)
	/usr/local/go/src/net/http/server.go:1895 +0x86c
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2933 +0x35c
runtime error: invalid memory address or nil pointer dereference
```
It seems that if the response either is not saved (or perhaps not yet saved?), the `reqLogs[i].Response` was `nil`, causing a crash. 
I also rewrote the loops to be more go-idiomatic. 