### PR TITLE
Open project on start

### DIFF
--- a/cmd/hetty/main.go
+++ b/cmd/hetty/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"log"
@@ -27,6 +28,7 @@ var (
 	caCertFile string
 	caKeyFile  string
 	projPath   string
+	projName   string
 	addr       string
 	adminPath  string
 )
@@ -35,6 +37,7 @@ func main() {
 	flag.StringVar(&caCertFile, "cert", "~/.hetty/hetty_cert.pem", "CA certificate filepath. Creates a new CA certificate is file doesn't exist")
 	flag.StringVar(&caKeyFile, "key", "~/.hetty/hetty_key.pem", "CA private key filepath. Creates a new CA private key if file doesn't exist")
 	flag.StringVar(&projPath, "projects", "~/.hetty/projects", "Projects directory path")
+	flag.StringVar(&projName, "project", "", "Project to open on start")
 	flag.StringVar(&addr, "addr", ":8080", "TCP address to listen on, in the form \"host:port\"")
 	flag.StringVar(&adminPath, "adminPath", "", "File path to admin build")
 	flag.Parse()
@@ -70,6 +73,10 @@ func main() {
 		log.Fatalf("[FATAL] Could not create new project service: %v", err)
 	}
 	defer projService.Close()
+
+	if projName != "" {
+		projService.Open(context.Background(), projName)
+	}
 
 	scope := scope.New(db, projService)
 

--- a/cmd/hetty/main.go
+++ b/cmd/hetty/main.go
@@ -75,7 +75,10 @@ func main() {
 	defer projService.Close()
 
 	if projName != "" {
-		projService.Open(context.Background(), projName)
+		_, err = projService.Open(context.Background(), projName)
+		if err != nil {
+			log.Fatalf("[FATAL] Could not open project: %v", err)
+		}
 	}
 
 	scope := scope.New(db, projService)


### PR DESCRIPTION
This PR closes #52. This is a bare minimum but it solves the issue.

The behavior that users might not expect is opening a new project if there's no such project already (as long as the name matches the regex). I can work on adding some additional logic to check for that, but personally, I see no issues with it - you can always remove the project created by accident.