### PR TITLE
Fix typo "is" > "if" in CLI cert help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Usage of ./hetty:
   -adminPath string
         File path to admin build
   -cert string
-        CA certificate filepath. Creates a new CA certificate is file doesn't exist (default "~/.hetty/hetty_cert.pem")
+        CA certificate filepath. Creates a new CA certificate if file doesn't exist (default "~/.hetty/hetty_cert.pem")
   -key string
         CA private key filepath. Creates a new CA private key if file doesn't exist (default "~/.hetty/hetty_key.pem")
   -projects string

--- a/cmd/hetty/main.go
+++ b/cmd/hetty/main.go
@@ -32,7 +32,7 @@ var (
 )
 
 func main() {
-	flag.StringVar(&caCertFile, "cert", "~/.hetty/hetty_cert.pem", "CA certificate filepath. Creates a new CA certificate is file doesn't exist")
+	flag.StringVar(&caCertFile, "cert", "~/.hetty/hetty_cert.pem", "CA certificate filepath. Creates a new CA certificate if file doesn't exist")
 	flag.StringVar(&caKeyFile, "key", "~/.hetty/hetty_key.pem", "CA private key filepath. Creates a new CA private key if file doesn't exist")
 	flag.StringVar(&projPath, "projects", "~/.hetty/projects", "Projects directory path")
 	flag.StringVar(&addr, "addr", ":8080", "TCP address to listen on, in the form \"host:port\"")

--- a/docs/src/guide/getting-started.md
+++ b/docs/src/guide/getting-started.md
@@ -77,7 +77,7 @@ Usage of ./hetty:
   -adminPath string
         File path to admin build
   -cert string
-        CA certificate filepath. Creates a new CA certificate is file doesn't exist (default "~/.hetty/hetty_cert.pem")
+        CA certificate filepath. Creates a new CA certificate if file doesn't exist (default "~/.hetty/hetty_cert.pem")
   -key string
         CA private key filepath. Creates a new CA private key if file doesn't exist (default "~/.hetty/hetty_key.pem")
   -projects string


### PR DESCRIPTION
Fixes #61.