### PR TITLE
fix proxy memory leak

### DIFF
--- a/pkg/proxy/net.go
+++ b/pkg/proxy/net.go
@@ -41,7 +41,11 @@ type ConnNotify struct {
 	closed chan struct{}
 }
 
-func (c *ConnNotify) Close() {
-	c.Conn.Close()
-	c.closed <- struct{}{}
+func (c *ConnNotify) Close() error {
+	err := c.Conn.Close()
+	select {
+	case c.closed <- struct{}{}:
+	default:
+	}
+	return err
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -208,8 +208,8 @@ func (p *Proxy) handleConnect(w http.ResponseWriter) {
 		return
 	}
 
-	clientConnNotify := ConnNotify{tlsConn, make(chan struct{})}
-	l := &OnceAcceptListener{clientConnNotify.Conn}
+	clientConnNotify := &ConnNotify{tlsConn, make(chan struct{})}
+	l := &OnceAcceptListener{clientConnNotify}
 
 	err = http.Serve(l, p)
 	if err != nil && !errors.Is(err, ErrAlreadyAccepted) {


### PR DESCRIPTION
clientConnNotify.closed is empty after net.Conn close, it will cause memory leak