### PR TITLE
fix(intercept): guard nil modReq in ModifyRequest

### DIFF
--- a/pkg/proxy/intercept/intercept.go
+++ b/pkg/proxy/intercept/intercept.go
@@ -192,9 +192,11 @@ func (svc *Service) ModifyRequest(reqID ulid.ULID, modReq *http.Request, modifyR
 		return ErrRequestNotFound
 	}
 
-	*modReq = *modReq.WithContext(req.req.Context())
-	if modifyResponse != nil {
-		*modReq = *modReq.WithContext(WithInterceptResponse(modReq.Context(), *modifyResponse))
+	if modReq != nil {
+		*modReq = *modReq.WithContext(req.req.Context())
+		if modifyResponse != nil {
+			*modReq = *modReq.WithContext(WithInterceptResponse(modReq.Context(), *modifyResponse))
+		}
 	}
 
 	select {

--- a/pkg/proxy/intercept/intercept_test.go
+++ b/pkg/proxy/intercept/intercept_test.go
@@ -130,6 +130,64 @@ func TestRequestModifier(t *testing.T) {
 	})
 }
 
+func TestCancelRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cancel intercepted request does not panic", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest("GET", "https://example.com/foo", nil)
+		reqID := ulid.MustNew(ulid.Timestamp(time.Now()), ulidEntropy)
+		*req = *req.WithContext(proxy.WithRequestID(req.Context(), reqID))
+
+		logger, _ := zap.NewDevelopment()
+		svc := intercept.NewService(intercept.Config{
+			Logger:           logger.Sugar(),
+			RequestsEnabled:  true,
+			ResponsesEnabled: false,
+		})
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		next := func(req *http.Request) {}
+		go func() {
+			defer wg.Done()
+			svc.RequestModifier(next)(req)
+		}()
+
+		// Wait shortly, to allow the req modifier goroutine to add `req` to the
+		// array of intercepted reqs.
+		time.Sleep(10 * time.Millisecond)
+
+		// CancelRequest forwards a nil *http.Request through ModifyRequest;
+		// this should not panic and should signal the interceptor to abort.
+		if err := svc.CancelRequest(reqID); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("cancel request that's not found", func(t *testing.T) {
+		t.Parallel()
+
+		logger, _ := zap.NewDevelopment()
+		svc := intercept.NewService(intercept.Config{
+			Logger:           logger.Sugar(),
+			RequestsEnabled:  true,
+			ResponsesEnabled: false,
+		})
+
+		reqID := ulid.MustNew(ulid.Timestamp(time.Now()), ulidEntropy)
+
+		err := svc.CancelRequest(reqID)
+		if !errors.Is(err, intercept.ErrRequestNotFound) {
+			t.Fatalf("expected `intercept.ErrRequestNotFound`, got: %v", err)
+		}
+	})
+}
+
 func TestResponseModifier(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #145.

`CancelRequest` calls `ModifyRequest(reqID, nil, nil)` to send a nil sentinel through the request channel, signalling the receiver in `InterceptRequest` to abort with `ErrRequestAborted`. However, `ModifyRequest` unconditionally dereferenced `modReq` (`*modReq = *modReq.WithContext(...)`) before forwarding it to the channel, panicking with `runtime error: invalid memory address or nil pointer dereference` whenever a user cancelled an intercepted request from the admin UI.

This guards the dereference behind a nil check so the nil sentinel propagates to the receiver, which already handles the abort. The fix mirrors the existing nil-guard pattern in `ModifyResponse`.

Includes a regression test covering both `CancelRequest` on an intercepted request (previously panicked) and on an unknown request (returns `ErrRequestNotFound`).