### PR TITLE
Document source build/install flow and make build-admin idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ build-admin:
 	cd admin && \
 	yarn install --frozen-lockfile && \
 	yarn run export && \
-    mv dist ../cmd/hetty/admin
+	rm -rf ../cmd/hetty/admin && \
+	cp -R dist ../cmd/hetty/admin
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -62,9 +62,21 @@ scoop install hettysoft/hetty
 
 Alternatively, you can [download the latest release from
 GitHub](https://github.com/dstotijn/hetty/releases/latest) for your OS and
-architecture, and move the binary to a directory in your `$PATH`. If your OS is
-not available for one of the package managers or not listed in the GitHub
-releases, you can compile from source _(link coming soon)_.
+architecture, and move the binary to a directory in your `$PATH`.
+
+If you want to compile from source, first build the admin frontend and then
+build the Go binary:
+
+```sh
+make build-admin
+go build ./cmd/hetty
+```
+
+To install the binary into your `$PATH`, run:
+
+```sh
+go install ./cmd/hetty
+```
 
 #### Docker
 


### PR DESCRIPTION
## Summary

- Documents how to build hetty from source in README.md, covering both the admin frontend and Go backend steps
- Adds `go install` instructions for installing the binary directly
- Makes the `build-admin` Makefile target idempotent by replacing `mv dist ../cmd/hetty/admin` with `rm -rf ../cmd/hetty/admin && cp -R dist ../cmd/hetty/admin`, so repeated builds don't fail

## Changes

- `README.md`: Added **Building from source** and **Installing from source** sections
- `Makefile`: Fixed `build-admin` target to be re-runnable without error