### PR TITLE
docs: fix README backlog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ features tailored to the needs of the infosec and bug bounty community.
 - Project based database storage, to help keep work organized
 
 👷‍♂️ Hetty is under active development. Check the <a
-href="https://github.com/dstotijn/hetty/projects/1">backlog</a> for the current
+href="https://github.com/dstotijn/hetty/issues">open issues</a> for the current
 status.
 
 📣 Are you pen testing professionaly in a team? I would love to hear your


### PR DESCRIPTION
Closes #150.

## Summary
- Replace the broken GitHub Projects classic backlog link with the repository's open issues page.

## Validation
- `git diff --check`
- Verified `https://github.com/dstotijn/hetty/issues` returns HTTP 200.