### PR TITLE
Harden filter parser/lexer against malicious search expressions (DoS)

### DIFF
--- a/pkg/filter/lexer.go
+++ b/pkg/filter/lexer.go
@@ -2,6 +2,8 @@ package filter
 
 import (
 	"fmt"
+	"runtime"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
@@ -72,17 +74,20 @@ var (
 type stateFn func(*Lexer) stateFn
 
 type Lexer struct {
-	input  string
-	pos    int
-	start  int
-	width  int
-	tokens chan Token
+	input    string
+	pos      int
+	start    int
+	width    int
+	tokens   chan Token
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 func NewLexer(input string) *Lexer {
 	l := &Lexer{
 		input:  input,
 		tokens: make(chan Token),
+		done:   make(chan struct{}),
 	}
 
 	go l.run(begin)
@@ -94,6 +99,17 @@ func (l *Lexer) Next() Token {
 	return <-l.tokens
 }
 
+// Stop signals the lexer goroutine to terminate. It must be called by consumers
+// that stop reading tokens before EOF (e.g. when parsing fails mid-stream),
+// otherwise the goroutine started by NewLexer blocks forever on an unbuffered
+// channel send and leaks. Stop is safe to call multiple times and from any
+// goroutine.
+func (l *Lexer) Stop() {
+	l.stopOnce.Do(func() {
+		close(l.done)
+	})
+}
+
 func (tt TokenType) String() string {
 	if typeString, ok := tokenTypeStrings[tt]; ok {
 		return typeString
@@ -103,10 +119,13 @@ func (tt TokenType) String() string {
 }
 
 func (l *Lexer) run(init stateFn) {
+	// Closing on return guarantees the channel is closed even when a send is
+	// abandoned via runtime.Goexit (see emit/errorf) after Stop was called.
+	defer close(l.tokens)
+
 	for nextState := init; nextState != nil; {
 		nextState = nextState(l)
 	}
-	close(l.tokens)
 }
 
 func (l *Lexer) read() (r rune) {
@@ -122,12 +141,17 @@ func (l *Lexer) read() (r rune) {
 }
 
 func (l *Lexer) emit(tokenType TokenType) {
-	l.tokens <- Token{
+	select {
+	case l.tokens <- Token{
 		Type:    tokenType,
 		Literal: l.input[l.start:l.pos],
+	}:
+		l.start = l.pos
+	case <-l.done:
+		// Consumer stopped reading; abandon the goroutine instead of blocking
+		// forever. Deferred close(l.tokens) in run still executes.
+		runtime.Goexit()
 	}
-
-	l.start = l.pos
 }
 
 func (l *Lexer) ignore() {
@@ -144,9 +168,13 @@ func (l *Lexer) backup() {
 }
 
 func (l *Lexer) errorf(format string, args ...interface{}) stateFn {
-	l.tokens <- Token{
+	select {
+	case l.tokens <- Token{
 		Type:    TokInvalid,
 		Literal: fmt.Sprintf(format, args...),
+	}:
+	case <-l.done:
+		runtime.Goexit()
 	}
 
 	return nil

--- a/pkg/filter/lexer_leak_test.go
+++ b/pkg/filter/lexer_leak_test.go
@@ -1,0 +1,54 @@
+package filter
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestParseQueryNoGoroutineLeak is a regression test for a goroutine leak in
+// the lexer. NewLexer spawns a goroutine that emits tokens on an unbuffered
+// channel. When ParseQuery returns early on a parse error, it used to stop
+// reading tokens, leaving that goroutine blocked forever on a channel send.
+// Because ParseQuery is reachable from the (unauthenticated) GraphQL API via
+// search expressions, repeated malformed queries leaked one goroutine each,
+// enabling a memory/goroutine-exhaustion denial of service.
+func TestParseQueryNoGoroutineLeak(t *testing.T) {
+	// Inputs that make ParseQuery return an error before the lexer reaches EOF.
+	malformed := []string{
+		"= foo",
+		"!= bar",
+		"(foo",
+		"=~ baz",
+		"NOT",
+	}
+
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	const iterations = 500
+	for i := 0; i < iterations; i++ {
+		input := malformed[i%len(malformed)]
+		if _, err := ParseQuery(input); err == nil {
+			t.Fatalf("expected parse error for input %q", input)
+		}
+	}
+
+	// Give any abandoned goroutines a chance to settle.
+	deadline := time.Now().Add(2 * time.Second)
+	var after int
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		after = runtime.NumGoroutine()
+		if after-before <= 5 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if leaked := after - before; leaked > 5 {
+		t.Fatalf("goroutine leak: %d goroutines still running after %d malformed queries (before=%d, after=%d)",
+			leaked, iterations, before, after)
+	}
+}

--- a/pkg/filter/parser.go
+++ b/pkg/filter/parser.go
@@ -68,10 +68,23 @@ func init() {
 	prefixParsers[TokParenOpen] = parseGroupedExpression
 }
 
+// maxParseDepth bounds the recursion depth of the parser. Filter expressions
+// are short, human-written search queries, so any legitimate query nests far
+// below this limit. Without a bound, deeply nested input (e.g. many "(" or
+// repeated "NOT" prefixes) recurses until the goroutine stack is exhausted,
+// which is a *fatal*, unrecoverable runtime error in Go (it cannot be caught by
+// recover, so it crashes the whole process). ParseQuery is reachable from the
+// unauthenticated GraphQL API via search expressions, so this would be a remote
+// denial of service.
+const maxParseDepth = 256
+
+var ErrMaxDepthExceeded = fmt.Errorf("filter: expression nesting exceeds maximum depth of %d", maxParseDepth)
+
 type Parser struct {
-	l    *Lexer
-	cur  Token
-	peek Token
+	l     *Lexer
+	cur   Token
+	peek  Token
+	depth int
 }
 
 func NewParser(l *Lexer) *Parser {
@@ -147,6 +160,16 @@ func (p *Parser) peekPrecedence() precedence {
 }
 
 func (p *Parser) parseExpression(prec precedence) (Expression, error) {
+	// Guard against stack exhaustion from deeply nested input. parseExpression
+	// is the single recursion point reached by grouped, prefix and infix
+	// sub-expression parsing, so bounding it here bounds total recursion depth.
+	p.depth++
+	defer func() { p.depth-- }()
+
+	if p.depth > maxParseDepth {
+		return nil, ErrMaxDepthExceeded
+	}
+
 	prefixParser, ok := prefixParsers[p.cur.Type]
 	if !ok {
 		return nil, fmt.Errorf("no prefix parse function for %v found", p.cur.Type)

--- a/pkg/filter/parser.go
+++ b/pkg/filter/parser.go
@@ -84,6 +84,10 @@ func NewParser(l *Lexer) *Parser {
 
 func ParseQuery(input string) (expr Expression, err error) {
 	p := &Parser{l: NewLexer(input)}
+	// Ensure the lexer goroutine is always released, including on early returns
+	// caused by parse errors that leave unread tokens on the channel.
+	defer p.l.Stop()
+
 	p.nextToken()
 	p.nextToken()
 

--- a/pkg/filter/parser_depth_test.go
+++ b/pkg/filter/parser_depth_test.go
@@ -1,0 +1,53 @@
+package filter
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestParseQueryDepthLimit is a regression test for an unrecoverable stack
+// overflow in the recursive-descent parser. Deeply nested input (many "(" or
+// repeated "NOT") used to recurse until the goroutine stack was exhausted,
+// which is a fatal runtime error in Go that recover() cannot catch and that
+// therefore crashes the whole process. ParseQuery is reachable from the
+// unauthenticated GraphQL API, making this a remote denial of service.
+func TestParseQueryDepthLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"deeply nested parentheses", strings.Repeat("(", 1_000_000)},
+		{"repeated NOT prefix", strings.Repeat("NOT ", 1_000_000)},
+		{"deeply nested groups", strings.Repeat("(", 100_000) + "foo" + strings.Repeat(")", 100_000)},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Must return an error instead of crashing the process.
+			_, err := ParseQuery(tt.input)
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !errors.Is(err, ErrMaxDepthExceeded) {
+				t.Fatalf("expected ErrMaxDepthExceeded, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestParseQueryReasonableNestingStillWorks ensures the depth guard doesn't
+// reject legitimate, modestly nested expressions.
+func TestParseQueryReasonableNestingStillWorks(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Repeat("(", 10) + "foo" + strings.Repeat(")", 10)
+	if _, err := ParseQuery(input); err != nil {
+		t.Fatalf("legitimate nested expression should parse, got error: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #153 .

`filter.ParseQuery` is reachable from the **unauthenticated** GraphQL API via
search/filter fields (`setHttpRequestLogFilter`, `setSenderRequestFilter`,
`updateInterceptSettings`). This PR fixes two denial-of-service issues in
`pkg/filter`.

## 1. Stack overflow → whole-process crash (critical)

The recursive-descent parser had no depth limit. Deeply nested input — many
`(` or repeated `NOT` — recurses through `parseExpression` until the goroutine
stack is exhausted. In Go a stack overflow is a **fatal** runtime error: it
**cannot** be caught by `recover()`, so gqlgen's panic-recovery middleware does
not contain it and the **entire process** crashes (proxy, admin API and all
in-flight intercepts). The parse happens before the "no active project" check,
so no project/auth/setup is required.

**Fix:** add a `maxParseDepth` (256) guard in `parseExpression`, the single
recursion point reached by grouped/prefix/infix sub-expression parsing.
Legitimate, human-written queries nest far below this.

## 2. Lexer goroutine leak (high)

`NewLexer` runs a goroutine that emits tokens on an unbuffered channel. When
`ParseQuery` returned early on a parse error it stopped draining the channel,
leaving that goroutine blocked on its send forever. Every malformed query
leaked one goroutine → gradual goroutine/memory exhaustion, also remotely
triggerable.

**Fix:** make the lexer cancellable (a `done` channel + `Stop()`); `ParseQuery`
defers `Stop()` so the goroutine is released on every return path.

## How to verify

Crash on current `main`:
```sh
cat > pkg/filter/poc_test.go <<'EOF'
package filter
import ("strings";"testing")
func TestPoC(t *testing.T){ ParseQuery(strings.Repeat("(", 2_000_000)) }
EOF
go test ./pkg/filter/ -run TestPoC   # => fatal error: stack overflow
rm pkg/filter/poc_test.go
```

With this PR:
```sh
go test ./pkg/filter/ -run 'Depth|Leak|Nesting' -v   # all PASS, no crash
go test ./pkg/filter/                                  # full suite green
```

## Tests added
- `TestParseQueryDepthLimit` — 1M-deep `(` / `NOT` / nested-group inputs now
  return `ErrMaxDepthExceeded` instead of crashing.
- `TestParseQueryReasonableNestingStillWorks` — legitimate nesting still parses.
- Goroutine-leak regression test.

No behavior change for valid expressions; no public API change.
