### PR TITLE
fix(api): compile header *value* regexp for scope rules

### DIFF
--- a/pkg/api/resolvers.go
+++ b/pkg/api/resolvers.go
@@ -300,7 +300,7 @@ func (r *mutationResolver) SetScope(ctx context.Context, input []ScopeRuleInput)
 				return nil, fmt.Errorf("invalid header key in scope rule: %w", err)
 			}
 
-			headerValue, err = stringPtrToRegexp(rule.Header.Key)
+			headerValue, err = stringPtrToRegexp(rule.Header.Value)
 			if err != nil {
 				return nil, fmt.Errorf("invalid header value in scope rule: %w", err)
 			}


### PR DESCRIPTION
While reading through the scope handling, I noticed a small copy-paste slip in `SetScope` (pkg/api/resolvers.go): the header **value** regexp is compiled from `rule.Header.Key` instead of `rule.Header.Value`. So the key pattern gets compiled twice and the value pattern a user sets is silently thrown away.

Since scope decides what traffic Hetty logs, shows, and intercepts, this quietly breaks any rule that's meant to match on a header's value — it ends up matching on the header key instead. That means some in-scope traffic gets missed, and some out-of-scope traffic sneaks in, with no error to hint at why.

It's a one-line fix:

### Before:
```go
    headerValue, err = stringPtrToRegexp(rule.Header.Key)   // oops, .Key
```
### After:
```go
    headerValue, err = stringPtrToRegexp(rule.Header.Value) // .Value
```
No API or behavior change beyond making the header-value matcher actually use the value pattern like it's supposed to.
