### PR TITLE
Fix nil pointer panic when cancelling an intercepted request

### DIFF
--- a/pkg/proxy/intercept/intercept.go
+++ b/pkg/proxy/intercept/intercept.go
@@ -192,6 +192,17 @@ func (svc *Service) ModifyRequest(reqID ulid.ULID, modReq *http.Request, modifyR
 		return ErrRequestNotFound
 	}
 
+	// A nil modReq signals that the request should be dropped. Avoid
+	// dereferencing it and forward nil to the channel as the abort signal.
+	if modReq == nil {
+		select {
+		case <-req.done:
+			return ErrRequestDone
+		case req.ch <- nil:
+			return nil
+		}
+	}
+
 	*modReq = *modReq.WithContext(req.req.Context())
 	if modifyResponse != nil {
 		*modReq = *modReq.WithContext(WithInterceptResponse(modReq.Context(), *modifyResponse))

--- a/pkg/proxy/intercept/intercept_test.go
+++ b/pkg/proxy/intercept/intercept_test.go
@@ -128,6 +128,52 @@ func TestRequestModifier(t *testing.T) {
 			t.Fatalf("incorrect modified request header value (expected: %v, got: %v)", exp, got.Header.Get("X-Foo"))
 		}
 	})
+
+	t.Run("cancel a pending request", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest("GET", "https://example.com/foo", nil)
+
+		reqID := ulid.MustNew(ulid.Timestamp(time.Now()), ulidEntropy)
+		*req = *req.WithContext(proxy.WithRequestID(req.Context(), reqID))
+
+		logger, _ := zap.NewDevelopment()
+		svc := intercept.NewService(intercept.Config{
+			Logger:           logger.Sugar(),
+			RequestsEnabled:  true,
+			ResponsesEnabled: false,
+		})
+
+		var nextCalled bool
+
+		next := func(req *http.Request) {
+			nextCalled = true
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go func() {
+			svc.RequestModifier(next)(req)
+			wg.Done()
+		}()
+
+		// Wait shortly, to allow the req modifier goroutine to add `req` to the
+		// array of intercepted reqs.
+		time.Sleep(10 * time.Millisecond)
+
+		// CancelRequest passes a nil request through ModifyRequest, which used to
+		// panic on a nil pointer dereference instead of aborting the request.
+		if err := svc.CancelRequest(reqID); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wg.Wait()
+
+		if nextCalled {
+			t.Fatal("expected next not to be called for a cancelled request")
+		}
+	})
 }
 
 func TestResponseModifier(t *testing.T) {


### PR DESCRIPTION
`CancelRequest` calls `ModifyRequest(reqID, nil, nil)` to abort an intercepted request, but `ModifyRequest` dereferences `modReq` (`*modReq = *modReq.WithContext(...)`) before checking it, so cancelling any intercepted request panics with a nil pointer dereference.

`ClearRequests` already aborts by sending `nil` straight to the request channel. This adds the same handling to `ModifyRequest`: when `modReq` is nil, forward `nil` to the channel as the abort signal instead of dereferencing it. The waiting `RequestModifier` then returns `ErrRequestAborted` as intended.

Added a regression test that cancels a pending intercepted request and confirms it no longer panics.

Fixes #145
