### PR TITLE
fix(proxy): use keyDir variable instead of string literal

### DIFF
--- a/pkg/proxy/cert.go
+++ b/pkg/proxy/cert.go
@@ -96,7 +96,7 @@ func LoadOrCreateCA(caKeyFile, caCertFile string) (*x509.Certificate, *rsa.Priva
 
 	keyDir, _ = filepath.Split(caCertFile)
 	if keyDir != "" {
-		if _, err := os.Stat("keyDir"); os.IsNotExist(err) {
+		if _, err := os.Stat(keyDir); os.IsNotExist(err) {
 			if err := os.MkdirAll(keyDir, 0o755); err != nil {
 				return nil, nil, fmt.Errorf("proxy: could not create directory for CA cert: %w", err)
 			}


### PR DESCRIPTION
## What
Fixes a one-line bug in `LoadOrCreateCA` where the CA-cert directory
existence check used the literal string `"keyDir"` instead of the
`keyDir` variable.

## Why
This means the directory-exists check never evaluates the real path,
so `os.MkdirAll` never runs for the CA cert directory when it's missing
— unlike the CA key directory check just above it, which correctly
uses the variable.

Fixes #147

## Testing
`go build ./pkg/proxy/` and `go vet ./pkg/proxy/` pass locally.